### PR TITLE
Add transaction image upload API and storage

### DIFF
--- a/app/Http/Controllers/Api/ImageUploadController.php
+++ b/app/Http/Controllers/Api/ImageUploadController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UploadImageRequest;
+use App\Models\TransactionImage;
+use App\Services\ImageStorageService;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\JsonResponse;
+use Carbon\Carbon;
+
+class ImageUploadController extends Controller
+{
+    protected ImageStorageService $storageService;
+
+    public function __construct(ImageStorageService $storageService)
+    {
+        $this->storageService = $storageService;
+    }
+
+    public function upload(UploadImageRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+
+        // parse captured datetime
+        if (!empty($data['capture_datetime'])) {
+            $capturedAt = Carbon::parse($data['capture_datetime']);
+        } elseif (!empty($data['capture_date']) && !empty($data['capture_time'])) {
+            $capturedAt = Carbon::parse($data['capture_date'] . ' ' . $data['capture_time']);
+        } else {
+            return response()->json(['message' => 'capture_datetime or capture_date+capture_time required'], 400);
+        }
+
+        $transactionId = $data['transaction_id'];
+        $cameraNo = $data['camera_no'];
+
+        // decode base64
+        $b64 = $data['image_base64'];
+        if (preg_match('/^data:(.*);base64,/', $b64)) {
+            $b64 = substr($b64, strpos($b64, ',') + 1);
+        }
+        $bytes = base64_decode($b64, true);
+        if ($bytes === false) {
+            return response()->json(['message' => 'Invalid base64 image'], 400);
+        }
+
+        $size = strlen($bytes);
+        $max = config('image.max_bytes', 5 * 1024 * 1024);
+        if ($size > $max) {
+            return response()->json(['message' => 'Image too large'], 413);
+        }
+
+        // infer mime if not provided
+        $contentType = $data['content_type'] ?? null;
+        if (!$contentType) {
+            $finfo = new \finfo(FILEINFO_MIME_TYPE);
+            $contentType = $finfo->buffer($bytes) ?: 'image/png';
+        }
+        if (!in_array($contentType, ['image/png', 'image/jpeg'])) {
+            return response()->json(['message' => 'Unsupported image type: ' . $contentType], 400);
+        }
+
+        $checksum = $data['checksum'] ?? hash('sha256', $bytes);
+
+        // idempotency: check existing by txn+cam+time
+        $existing = TransactionImage::where('transaction_id', $transactionId)
+            ->where('camera_no', $cameraNo)
+            ->where('captured_at', $capturedAt)
+            ->first();
+        if ($existing) {
+            return response()->json([
+                'id' => $existing->id,
+                'image_path' => $existing->image_path
+            ], 200);
+        }
+
+        // save bytes via service
+        try {
+            $meta = $this->storageService->saveBytes($bytes, $transactionId, $cameraNo, $capturedAt, $contentType);
+        } catch (\Exception $e) {
+            Log::error('Image save failed: ' . $e->getMessage());
+            return response()->json(['message' => 'Failed to save image'], 500);
+        }
+
+        // insert DB record
+        $rec = TransactionImage::create([
+            'transaction_id' => $transactionId,
+            'camera_no' => $cameraNo,
+            'captured_at' => $capturedAt,
+            'image_path' => $meta['path'],
+            'storage_backend' => 'local',
+            'content_type' => $meta['content_type'],
+            'size_bytes' => $meta['size'],
+            'checksum_sha256' => $meta['checksum'],
+            'ingest_status' => 'stored'
+        ]);
+
+        $url = Storage::disk('public')->url($meta['path']);
+
+        return response()->json([
+            'id' => $rec->id,
+            'image_path' => $meta['path'],
+            'url' => $url
+        ], 201);
+    }
+}

--- a/app/Http/Requests/UploadImageRequest.php
+++ b/app/Http/Requests/UploadImageRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UploadImageRequest extends FormRequest
+{
+    public function authorize()
+    {
+        // Use middleware for auth; allow here
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'transaction_id' => 'required|string|max:128',
+            'camera_no' => 'required|string|max:16',
+            'capture_datetime' => 'nullable|date',
+            'capture_date' => 'nullable|date',
+            'capture_time' => 'nullable|string',
+            'image_base64' => 'required|string',
+            'content_type' => 'nullable|string',
+            'checksum' => 'nullable|string'
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'transaction_id.required' => 'transaction_id is required',
+            'camera_no.required' => 'camera_no is required',
+            'image_base64.required' => 'image_base64 is required',
+        ];
+    }
+}

--- a/app/Models/TransactionImage.php
+++ b/app/Models/TransactionImage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TransactionImage extends Model
+{
+    use HasFactory;
+
+    protected $table = 'transaction_images';
+
+    protected $fillable = [
+        'transaction_id',
+        'camera_no',
+        'captured_at',
+        'image_path',
+        'storage_backend',
+        'content_type',
+        'size_bytes',
+        'checksum_sha256',
+        'ingest_status',
+        'extra_meta'
+    ];
+
+    protected $casts = [
+        'captured_at' => 'datetime',
+        'extra_meta' => 'array'
+    ];
+}

--- a/app/Services/ImageStorageService.php
+++ b/app/Services/ImageStorageService.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+use Carbon\Carbon;
+
+class ImageStorageService
+{
+    /**
+     * Save raw image bytes to configured disk and return metadata.
+     * Optionally convert to webp if configured/possible.
+     *
+     * @param string $bytes
+     * @param string $transactionId
+     * @param string $cameraNo
+     * @param \DateTimeInterface $capturedAt
+     * @param string|null $contentType
+     * @return array
+     */
+    public function saveBytes(string $bytes, string $transactionId, string $cameraNo, \DateTimeInterface $capturedAt, ?string $contentType = null): array
+    {
+        $date = Carbon::instance($capturedAt)->format('Y-m-d');
+        $checksum = hash('sha256', $bytes);
+        $ext = 'png';
+        if ($contentType === 'image/jpeg') {
+            $ext = 'jpg';
+        }
+
+        // generate filename
+        $filename = sprintf('%s_%s_%s_%s.%s', $transactionId, $cameraNo, $capturedAt->format('His_u'), substr($checksum, 0, 8), $ext);
+        $path = "images/{$date}/{$transactionId}/{$filename}";
+
+        // ensure directory
+        Storage::disk('public')->put($path, $bytes);
+        $size = Storage::disk('public')->size($path);
+
+        // attempt webp conversion if Intervention available and GD supports webp
+        // do NOT overwrite original; store alongside
+        try {
+            if (extension_loaded('gd') || extension_loaded('imagick')) {
+                $webpName = preg_replace('/\.[^.]+$/', '.webp', $filename);
+                $webpPath = "images/{$date}/{$transactionId}/{$webpName}";
+                $img = Image::make($bytes);
+                // you can set quality via config
+                $img->encode('webp', 80);
+                Storage::disk('public')->put($webpPath, (string)$img);
+            } else {
+                $webpPath = null;
+            }
+        } catch (\Exception $e) {
+            // conversion failed; ignore and continue
+            $webpPath = null;
+        }
+
+        return [
+            'path' => $path,
+            'webp_path' => $webpPath,
+            'size' => $size,
+            'checksum' => $checksum,
+            'content_type' => $contentType ?? 'image/png'
+        ];
+    }
+}

--- a/database/migrations/2025_09_03_000000_create_transaction_images_table.php
+++ b/database/migrations/2025_09_03_000000_create_transaction_images_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('transaction_images', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('transaction_id', 128)->index();
+            $table->string('camera_no', 16);
+            $table->timestampTz('captured_at');
+            $table->text('image_path');
+            $table->string('storage_backend', 32)->default('local');
+            $table->string('content_type', 64)->nullable();
+            $table->integer('size_bytes')->nullable();
+            $table->string('checksum_sha256', 64)->nullable();
+            $table->string('ingest_status', 32)->default('stored');
+            $table->json('extra_meta')->nullable();
+            $table->timestamps();
+
+            $table->unique(['transaction_id', 'camera_no', 'captured_at'], 'txn_cam_time_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('transaction_images');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -82,6 +82,7 @@ use App\Http\Controllers\Api\{
     WVendorController
 
 };
+use App\Http\Controllers\Api\ImageUploadController;
 use App\Http\Controllers\Api\Chicks\BreedController;
 use App\Http\Controllers\Api\Chicks\ChicksBookingController;
 use App\Http\Controllers\Api\Chicks\ChicksDailyPriceController;
@@ -123,6 +124,9 @@ use App\Services\SalesEmployeeSyncService;
     /////////////////////////////////////Weight Scale Route //////////////
 // 📝 Create (store)
 Route::post('/storeweight-transactions', [WeightTransactionController::class, 'store']);
+
+// Image upload from camera (one POST per camera)
+Route::post('/v1/images/upload', [ImageUploadController::class, 'upload']);
 
 // 📋 Read all (index)
 Route::get('/getweight-transactions', [WeightTransactionController::class, 'index']);


### PR DESCRIPTION
Introduces an endpoint for uploading transaction-related images via base64, including validation, storage, and database record creation. Adds ImageUploadController, request validation, TransactionImage model, storage service, and migration for the transaction_images table. Updates API routes to expose the new upload endpoint.